### PR TITLE
[#13] Service Worker attempts to cache network request from chrome extension

### DIFF
--- a/lib/generators/templates/install/service-worker.js
+++ b/lib/generators/templates/install/service-worker.js
@@ -33,8 +33,10 @@ var checkResponse = function(request) {
 var addToCache = function(request) {
     return caches.open('pwa-offline').then(function(cache) {
         return fetch(request).then(function(response) {
+          if (request.url) {
             console.log( '[PWA] Add page to cache: ', response.url );
             return cache.put( request, response );
+          }
         });
     });
 };


### PR DESCRIPTION
By adding a basic conditional to `addToCache` function we prevent the service worker from trying to cache these network requests.
